### PR TITLE
Modify Function called "Binary" in ./Our_Qiskit_Functions.py

### DIFF
--- a/Our_Qiskit_Functions.py
+++ b/Our_Qiskit_Functions.py
@@ -46,7 +46,7 @@ def Wavefunction( obj , *args, **kwargs):
 		#print(wavefunction)
 		value = round(statevec[i].real, dec) + round(statevec[i].imag, dec) * 1j
 		if( (value.real != 0) or (value.imag != 0)):
-			state = list(Binary(int(i),int(2**qubits)))
+			state = list(format(int(i),f"0{int(2**qubits)}b"))
 			state.reverse()
 			state_str = ''
 			#print(state)


### PR DESCRIPTION
We couldn't find a function called binary in Our_Qiskit_Functions. So, we got an error message on that.
I replaced Binary function with format function. 
It's working properly. 